### PR TITLE
update go to use OTEL_* env vars

### DIFF
--- a/01-manual/go-year/main.go
+++ b/01-manual/go-year/main.go
@@ -66,6 +66,28 @@ func getYear(ctx context.Context) int {
 }
 
 func initTracer() func() {
+
+	ctx := context.Background()
+
+	exporter, err := otlptracegrpc.New(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	provider := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exporter),
+	)
+	otel.SetTracerProvider(provider)
+
+	return func() {
+		ctx := context.Background()
+		err := provider.Shutdown(ctx)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+}
+
+func initTracerTheHardWay() func() {
 	apikey, _ := os.LookupEnv("HONEYCOMB_API_KEY")
 	dataset, _ := os.LookupEnv("HONEYCOMB_DATASET")
 

--- a/01-manual/run.sh
+++ b/01-manual/run.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+export OTEL_METRICS_EXPORTER="none"
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io:443"
+export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY},x-honeycomb-dataset=${HONEYCOMB_DATASET:-workshop}"
+export OTEL_SERVICE_NAME="$1"
+
 go_year() {
   cd go-year || exit
 
@@ -18,11 +23,6 @@ java_year() {
 
   gradle bootJar
 
-  export OTEL_METRICS_EXPORTER="none"
-  export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io"
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY},x-honeycomb-dataset=${HONEYCOMB_DATASET:-workshop}"
-  export OTEL_SERVICE_NAME="java-year"
-
   if [[ -n "$2" ]] && [[ "$2" == "-b" ]]; then
     java -javaagent:../../lib/opentelemetry-javaagent.jar -jar build/libs/java-year.jar &
   else
@@ -35,11 +35,6 @@ node_year() {
 
   npm install
 
-  export OTEL_METRICS_EXPORTER="none"
-  export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io"
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY},x-honeycomb-dataset=${HONEYCOMB_DATASET:-workshop}"
-  export OTEL_SERVICE_NAME="node-year"
-
   if [[ -n "$2" ]] && [[ "$2" == "-b" ]]; then
     node -r ./tracing.js node-year.js &
   else
@@ -51,11 +46,6 @@ python_year() {
   cd python-year || exit
 
   pip install -r requirements.txt
-
-  export OTEL_METRICS_EXPORTER="none"
-  export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io"
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY},x-honeycomb-dataset=${HONEYCOMB_DATASET:-workshop}"
-  export OTEL_SERVICE_NAME="python-year"
 
   if [[ -n "$2" ]] && [[ "$2" == "-b" ]]; then
     opentelemetry-instrument uvicorn python-year:app --host 0.0.0.0 --port 6001 &

--- a/01-manual/stop.sh
+++ b/01-manual/stop.sh
@@ -2,7 +2,7 @@
 
 case "$1" in
 
-"go-year" | "go-name" | "java-year" | "java-name" | "node-year" | "node-name")
+"go-year" | "go-name" | "java-year" | "java-name" | "node-year" | "python-year")
   pkill -f "$1"
   ;;
 
@@ -13,7 +13,7 @@ case "$1" in
   pkill -f java-year
   pkill -f java-name
   pkill -f node-year
-  pkill -f node-name
+  pkill -f python-year
   ;;
 
 *)

--- a/02-_start-asynchronous/run.sh
+++ b/02-_start-asynchronous/run.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+export OTEL_METRICS_EXPORTER="none"
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io:443"
+export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY},x-honeycomb-dataset=${HONEYCOMB_DATASET:-workshop}"
+export OTEL_SERVICE_NAME="$1"
+
 go_year() {
   cd go-year || exit
 
@@ -18,11 +23,6 @@ java_year() {
 
   gradle bootJar
 
-  export OTEL_METRICS_EXPORTER="none"
-  export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io"
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY},x-honeycomb-dataset=${HONEYCOMB_DATASET:-workshop}"
-  export OTEL_SERVICE_NAME="java-year"
-
   if [[ -n "$2" ]] && [[ "$2" == "-b" ]]; then
     java -javaagent:../../lib/opentelemetry-javaagent.jar -jar build/libs/java-year.jar &
   else
@@ -35,11 +35,6 @@ node_year() {
 
   npm install
 
-  export OTEL_METRICS_EXPORTER="none"
-  export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io"
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY},x-honeycomb-dataset=${HONEYCOMB_DATASET:-workshop}"
-  export OTEL_SERVICE_NAME="node-year"
-
   if [[ -n "$2" ]] && [[ "$2" == "-b" ]]; then
     node -r ./tracing.js node-year.js &
   else
@@ -51,11 +46,6 @@ python_year() {
   cd python-year || exit
 
   pip install -r requirements.txt
-
-  export OTEL_METRICS_EXPORTER="none"
-  export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io"
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY},x-honeycomb-dataset=${HONEYCOMB_DATASET:-workshop}"
-  export OTEL_SERVICE_NAME="python-year"
 
   if [[ -n "$2" ]] && [[ "$2" == "-b" ]]; then
     opentelemetry-instrument uvicorn python-year:app --host 0.0.0.0 --port 6001 &

--- a/02-_start-asynchronous/stop.sh
+++ b/02-_start-asynchronous/stop.sh
@@ -2,7 +2,7 @@
 
 case "$1" in
 
-"go-year" | "go-name" | "java-year" | "java-name" | "node-year" | "node-name")
+"go-year" | "go-name" | "java-year" | "java-name" | "node-year" | "python-year")
   pkill -f "$1"
   ;;
 
@@ -13,7 +13,7 @@ case "$1" in
   pkill -f java-year
   pkill -f java-name
   pkill -f node-year
-  pkill -f node-name
+  pkill -f python-year
   ;;
 
 *)

--- a/02-asynchronous/run.sh
+++ b/02-asynchronous/run.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+export OTEL_METRICS_EXPORTER="none"
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io:443"
+export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY},x-honeycomb-dataset=${HONEYCOMB_DATASET:-workshop}"
+export OTEL_SERVICE_NAME="$1"
+
 go_year() {
   cd go-year || exit
 
@@ -18,11 +23,6 @@ java_year() {
 
   gradle bootJar
 
-  export OTEL_METRICS_EXPORTER="none"
-  export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io"
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY},x-honeycomb-dataset=${HONEYCOMB_DATASET:-workshop}"
-  export OTEL_SERVICE_NAME="java-year"
-
   if [[ -n "$2" ]] && [[ "$2" == "-b" ]]; then
     java -javaagent:../../lib/opentelemetry-javaagent.jar -jar build/libs/java-year.jar &
   else
@@ -35,11 +35,6 @@ node_year() {
 
   npm install
 
-  export OTEL_METRICS_EXPORTER="none"
-  export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io"
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY},x-honeycomb-dataset=${HONEYCOMB_DATASET:-workshop}"
-  export OTEL_SERVICE_NAME="node-year"
-
   if [[ -n "$2" ]] && [[ "$2" == "-b" ]]; then
     node -r ./tracing.js node-year.js &
   else
@@ -51,11 +46,6 @@ python_year() {
   cd python-year || exit
 
   pip install -r requirements.txt
-
-  export OTEL_METRICS_EXPORTER="none"
-  export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io"
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY},x-honeycomb-dataset=${HONEYCOMB_DATASET:-workshop}"
-  export OTEL_SERVICE_NAME="python-year"
 
   if [[ -n "$2" ]] && [[ "$2" == "-b" ]]; then
     opentelemetry-instrument uvicorn python-year:app --host 0.0.0.0 --port 6001 &

--- a/02-asynchronous/stop.sh
+++ b/02-asynchronous/stop.sh
@@ -2,7 +2,7 @@
 
 case "$1" in
 
-"go-year" | "go-name" | "java-year" | "java-name" | "node-year" | "node-name")
+"go-year" | "go-name" | "java-year" | "java-name" | "node-year" | "python-year")
   pkill -f "$1"
   ;;
 
@@ -13,7 +13,7 @@ case "$1" in
   pkill -f java-year
   pkill -f java-name
   pkill -f node-year
-  pkill -f node-name
+  pkill -f python-year
   ;;
 
 *)

--- a/03-span-events/go-year/main.go
+++ b/03-span-events/go-year/main.go
@@ -6,20 +6,15 @@ import (
 	"log"
 	"math/rand"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/gorilla/mux"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
-	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	"go.opentelemetry.io/otel/trace"
-	"google.golang.org/grpc/credentials"
 )
 
 var years = []int{2015, 2016, 2017, 2018, 2019, 2020}
@@ -79,36 +74,18 @@ func getYear(ctx context.Context) int {
 }
 
 func initTracer() func() {
-	apikey, _ := os.LookupEnv("HONEYCOMB_API_KEY")
-	dataset, _ := os.LookupEnv("HONEYCOMB_DATASET")
 
-	// Set GRPC options to establish an insecure connection to an OpenTelemetry Collector
-	opts := []otlptracegrpc.Option{
-		otlptracegrpc.WithTLSCredentials(credentials.NewClientTLSFromCert(nil, "")),
-		otlptracegrpc.WithEndpoint("api.honeycomb.io:443"),
-		otlptracegrpc.WithHeaders(map[string]string{
-			"x-honeycomb-team":    apikey,
-			"x-honeycomb-dataset": dataset,
-		}),
-	}
+	ctx := context.Background()
 
-	// Create the exporter
-	exporter, err := otlptrace.New(context.Background(), otlptracegrpc.NewClient(opts...))
+	exporter, err := otlptracegrpc.New(ctx)
 	if err != nil {
-		log.Fatalf("failed to create Otel exporter: %v", err)
+		log.Fatal(err)
 	}
-
 	provider := sdktrace.NewTracerProvider(
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 		sdktrace.WithBatcher(exporter),
-		sdktrace.WithResource(resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceNameKey.String("go-year"),
-		)),
 	)
 	otel.SetTracerProvider(provider)
 
-	// This callback will ensure all spans get flushed before the program exits.
 	return func() {
 		ctx := context.Background()
 		err := provider.Shutdown(ctx)

--- a/03-span-events/run.sh
+++ b/03-span-events/run.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+export OTEL_METRICS_EXPORTER="none"
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io:443"
+export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY},x-honeycomb-dataset=${HONEYCOMB_DATASET:-workshop}"
+export OTEL_SERVICE_NAME="$1"
+
 go_year() {
   cd go-year || exit
 
@@ -18,11 +23,6 @@ java_year() {
 
   gradle bootJar
 
-  export OTEL_METRICS_EXPORTER="none"
-  export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io"
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY},x-honeycomb-dataset=${HONEYCOMB_DATASET:-workshop}"
-  export OTEL_SERVICE_NAME="java-year"
-
   if [[ -n "$2" ]] && [[ "$2" == "-b" ]]; then
     java -javaagent:../../lib/opentelemetry-javaagent.jar -jar build/libs/java-year.jar &
   else
@@ -35,11 +35,6 @@ node_year() {
 
   npm install
 
-  export OTEL_METRICS_EXPORTER="none"
-  export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io"
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY},x-honeycomb-dataset=${HONEYCOMB_DATASET:-workshop}"
-  export OTEL_SERVICE_NAME="node-year"
-
   if [[ -n "$2" ]] && [[ "$2" == "-b" ]]; then
     node -r ./tracing.js node-year.js &
   else
@@ -51,11 +46,6 @@ python_year() {
   cd python-year || exit
 
   pip install -r requirements.txt
-
-  export OTEL_METRICS_EXPORTER="none"
-  export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io"
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY},x-honeycomb-dataset=${HONEYCOMB_DATASET:-workshop}"
-  export OTEL_SERVICE_NAME="python-year"
 
   if [[ -n "$2" ]] && [[ "$2" == "-b" ]]; then
     opentelemetry-instrument uvicorn python-year:app --host 0.0.0.0 --port 6001 &

--- a/03-span-events/stop.sh
+++ b/03-span-events/stop.sh
@@ -2,7 +2,7 @@
 
 case "$1" in
 
-"go-year" | "go-name" | "java-year" | "java-name" | "node-year" | "node-name")
+"go-year" | "go-name" | "java-year" | "java-name" | "node-year" | "python-year")
   pkill -f "$1"
   ;;
 
@@ -13,7 +13,7 @@ case "$1" in
   pkill -f java-year
   pkill -f java-name
   pkill -f node-year
-  pkill -f node-name
+  pkill -f python-year
   ;;
 
 *)

--- a/04-span-links/go-year/main.go
+++ b/04-span-links/go-year/main.go
@@ -6,20 +6,15 @@ import (
 	"log"
 	"math/rand"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/gorilla/mux"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
-	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	"go.opentelemetry.io/otel/trace"
-	"google.golang.org/grpc/credentials"
 )
 
 var years = []int{2015, 2016, 2017, 2018, 2019, 2020}
@@ -108,36 +103,18 @@ func addRecursiveSpan(ctx context.Context, depth int, maxDepth int) {
 }
 
 func initTracer() func() {
-	apikey, _ := os.LookupEnv("HONEYCOMB_API_KEY")
-	dataset, _ := os.LookupEnv("HONEYCOMB_DATASET")
 
-	// Set GRPC options to establish an insecure connection to an OpenTelemetry Collector
-	opts := []otlptracegrpc.Option{
-		otlptracegrpc.WithTLSCredentials(credentials.NewClientTLSFromCert(nil, "")),
-		otlptracegrpc.WithEndpoint("api.honeycomb.io:443"),
-		otlptracegrpc.WithHeaders(map[string]string{
-			"x-honeycomb-team":    apikey,
-			"x-honeycomb-dataset": dataset,
-		}),
-	}
+	ctx := context.Background()
 
-	// Create the exporter
-	exporter, err := otlptrace.New(context.Background(), otlptracegrpc.NewClient(opts...))
+	exporter, err := otlptracegrpc.New(ctx)
 	if err != nil {
-		log.Fatalf("failed to create Otel exporter: %v", err)
+		log.Fatal(err)
 	}
-
 	provider := sdktrace.NewTracerProvider(
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 		sdktrace.WithBatcher(exporter),
-		sdktrace.WithResource(resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceNameKey.String("go-year"),
-		)),
 	)
 	otel.SetTracerProvider(provider)
 
-	// This callback will ensure all spans get flushed before the program exits.
 	return func() {
 		ctx := context.Background()
 		err := provider.Shutdown(ctx)

--- a/04-span-links/run.sh
+++ b/04-span-links/run.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+export OTEL_METRICS_EXPORTER="none"
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io:443"
+export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY},x-honeycomb-dataset=${HONEYCOMB_DATASET:-workshop}"
+export OTEL_SERVICE_NAME="$1"
+
 go_year() {
   cd go-year || exit
 
@@ -18,11 +23,6 @@ java_year() {
 
   gradle bootJar
 
-  export OTEL_METRICS_EXPORTER="none"
-  export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io"
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY},x-honeycomb-dataset=${HONEYCOMB_DATASET:-workshop}"
-  export OTEL_SERVICE_NAME="java-year"
-
   if [[ -n "$2" ]] && [[ "$2" == "-b" ]]; then
     java -javaagent:../../lib/opentelemetry-javaagent.jar -jar build/libs/java-year.jar &
   else
@@ -35,11 +35,6 @@ node_year() {
 
   npm install
 
-  export OTEL_METRICS_EXPORTER="none"
-  export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io"
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY},x-honeycomb-dataset=${HONEYCOMB_DATASET:-workshop}"
-  export OTEL_SERVICE_NAME="node-year"
-
   if [[ -n "$2" ]] && [[ "$2" == "-b" ]]; then
     node -r ./tracing.js node-year.js &
   else
@@ -51,11 +46,6 @@ python_year() {
   cd python-year || exit
 
   pip install -r requirements.txt
-
-  export OTEL_METRICS_EXPORTER="none"
-  export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io"
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY},x-honeycomb-dataset=${HONEYCOMB_DATASET:-workshop}"
-  export OTEL_SERVICE_NAME="python-year"
 
   if [[ -n "$2" ]] && [[ "$2" == "-b" ]]; then
     opentelemetry-instrument uvicorn python-year:app --host 0.0.0.0 --port 6001 &

--- a/04-span-links/stop.sh
+++ b/04-span-links/stop.sh
@@ -2,7 +2,7 @@
 
 case "$1" in
 
-"go-year" | "go-name" | "java-year" | "java-name" | "node-year" | "node-name")
+"go-year" | "go-name" | "java-year" | "java-name" | "node-year" | "python-year")
   pkill -f "$1"
   ;;
 
@@ -13,7 +13,7 @@ case "$1" in
   pkill -f java-year
   pkill -f java-name
   pkill -f node-year
-  pkill -f node-name
+  pkill -f python-year
   ;;
 
 *)

--- a/05-_start-propagation/go-year/main.go
+++ b/05-_start-propagation/go-year/main.go
@@ -6,20 +6,15 @@ import (
 	"log"
 	"math/rand"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/gorilla/mux"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
-	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	"go.opentelemetry.io/otel/trace"
-	"google.golang.org/grpc/credentials"
 )
 
 var years = []int{2015, 2016, 2017, 2018, 2019, 2020}
@@ -108,36 +103,18 @@ func addRecursiveSpan(ctx context.Context, depth int, maxDepth int) {
 }
 
 func initTracer() func() {
-	apikey, _ := os.LookupEnv("HONEYCOMB_API_KEY")
-	dataset, _ := os.LookupEnv("HONEYCOMB_DATASET")
 
-	// Set GRPC options to establish an insecure connection to an OpenTelemetry Collector
-	opts := []otlptracegrpc.Option{
-		otlptracegrpc.WithTLSCredentials(credentials.NewClientTLSFromCert(nil, "")),
-		otlptracegrpc.WithEndpoint("api.honeycomb.io:443"),
-		otlptracegrpc.WithHeaders(map[string]string{
-			"x-honeycomb-team":    apikey,
-			"x-honeycomb-dataset": dataset,
-		}),
-	}
+	ctx := context.Background()
 
-	// Create the exporter
-	exporter, err := otlptrace.New(context.Background(), otlptracegrpc.NewClient(opts...))
+	exporter, err := otlptracegrpc.New(ctx)
 	if err != nil {
-		log.Fatalf("failed to create Otel exporter: %v", err)
+		log.Fatal(err)
 	}
-
 	provider := sdktrace.NewTracerProvider(
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 		sdktrace.WithBatcher(exporter),
-		sdktrace.WithResource(resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceNameKey.String("go-year"),
-		)),
 	)
 	otel.SetTracerProvider(provider)
 
-	// This callback will ensure all spans get flushed before the program exits.
 	return func() {
 		ctx := context.Background()
 		err := provider.Shutdown(ctx)

--- a/05-_start-propagation/run.sh
+++ b/05-_start-propagation/run.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+export OTEL_METRICS_EXPORTER="none"
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io:443"
+export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY},x-honeycomb-dataset=${HONEYCOMB_DATASET:-workshop}"
+export OTEL_SERVICE_NAME="$1"
+
 go_name() {
   cd go-name || exit
 
@@ -30,11 +35,6 @@ java_year() {
 
   gradle bootJar
 
-  export OTEL_METRICS_EXPORTER="none"
-  export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io"
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY},x-honeycomb-dataset=${HONEYCOMB_DATASET:-workshop}"
-  export OTEL_SERVICE_NAME="java-year"
-
   if [[ -n "$2" ]] && [[ "$2" == "-b" ]]; then
     java -javaagent:../../lib/opentelemetry-javaagent.jar -jar build/libs/java-year.jar &
   else
@@ -47,11 +47,6 @@ node_year() {
 
   npm install
 
-  export OTEL_METRICS_EXPORTER="none"
-  export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io"
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY},x-honeycomb-dataset=${HONEYCOMB_DATASET:-workshop}"
-  export OTEL_SERVICE_NAME="node-year"
-
   if [[ -n "$2" ]] && [[ "$2" == "-b" ]]; then
     node -r ./tracing.js node-year.js &
   else
@@ -63,11 +58,6 @@ python_year() {
   cd python-year || exit
 
   pip install -r requirements.txt
-
-  export OTEL_METRICS_EXPORTER="none"
-  export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io"
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY},x-honeycomb-dataset=${HONEYCOMB_DATASET:-workshop}"
-  export OTEL_SERVICE_NAME="python-year"
 
   if [[ -n "$2" ]] && [[ "$2" == "-b" ]]; then
     opentelemetry-instrument uvicorn python-year:app --host 0.0.0.0 --port 6001 &
@@ -86,11 +76,6 @@ case $1 in
 "go-year")
   echo "go-year"
   go_year "$@"
-  ;;
-
-"java-name")
-  echo "java-name"
-  java_name "$@"
   ;;
 
 "java-year")

--- a/05-_start-propagation/stop.sh
+++ b/05-_start-propagation/stop.sh
@@ -2,7 +2,7 @@
 
 case "$1" in
 
-"go-year" | "go-name" | "java-year" | "java-name" | "node-year" | "node-name")
+"go-year" | "go-name" | "java-year" | "java-name" | "node-year" | "python-year")
   pkill -f "$1"
   ;;
 
@@ -13,7 +13,7 @@ case "$1" in
   pkill -f java-year
   pkill -f java-name
   pkill -f node-year
-  pkill -f node-name
+  pkill -f python-year
   ;;
 
 *)

--- a/05-propagation/go-year/main.go
+++ b/05-propagation/go-year/main.go
@@ -7,20 +7,15 @@ import (
 	"log"
 	"math/rand"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/gorilla/mux"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
-	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	"go.opentelemetry.io/otel/trace"
-	"google.golang.org/grpc/credentials"
 )
 
 var years = []int{2015, 2016, 2017, 2018, 2019, 2020}
@@ -109,38 +104,20 @@ func addRecursiveSpan(ctx context.Context, depth int, maxDepth int) {
 }
 
 func initTracer() func() {
-	apikey, _ := os.LookupEnv("HONEYCOMB_API_KEY")
-	dataset, _ := os.LookupEnv("HONEYCOMB_DATASET")
 
-	// Set GRPC options to establish an insecure connection to an OpenTelemetry Collector
-	opts := []otlptracegrpc.Option{
-		otlptracegrpc.WithTLSCredentials(credentials.NewClientTLSFromCert(nil, "")),
-		otlptracegrpc.WithEndpoint("api.honeycomb.io:443"),
-		otlptracegrpc.WithHeaders(map[string]string{
-			"x-honeycomb-team":    apikey,
-			"x-honeycomb-dataset": dataset,
-		}),
-	}
+	ctx := context.Background()
 
-	// Create the exporter
-	exporter, err := otlptrace.New(context.Background(), otlptracegrpc.NewClient(opts...))
+	exporter, err := otlptracegrpc.New(ctx)
 	if err != nil {
-		log.Fatalf("failed to create Otel exporter: %v", err)
+		log.Fatal(err)
 	}
-
 	provider := sdktrace.NewTracerProvider(
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 		sdktrace.WithBatcher(exporter),
-		sdktrace.WithResource(resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceNameKey.String("go-year"),
-		)),
 	)
 	otel.SetTracerProvider(provider)
 
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
 
-	// This callback will ensure all spans get flushed before the program exits.
 	return func() {
 		ctx := context.Background()
 		err := provider.Shutdown(ctx)

--- a/05-propagation/run.sh
+++ b/05-propagation/run.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+export OTEL_METRICS_EXPORTER="none"
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io:443"
+export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY},x-honeycomb-dataset=${HONEYCOMB_DATASET:-workshop}"
+export OTEL_SERVICE_NAME="$1"
+
 go_name() {
   cd go-name || exit
 
@@ -30,11 +35,6 @@ java_year() {
 
   gradle bootJar
 
-  export OTEL_METRICS_EXPORTER="none"
-  export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io"
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY},x-honeycomb-dataset=${HONEYCOMB_DATASET:-workshop}"
-  export OTEL_SERVICE_NAME="java-year"
-
   if [[ -n "$2" ]] && [[ "$2" == "-b" ]]; then
     java -javaagent:../../lib/opentelemetry-javaagent.jar -jar build/libs/java-year.jar &
   else
@@ -47,11 +47,6 @@ node_year() {
 
   npm install
 
-  export OTEL_METRICS_EXPORTER="none"
-  export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io"
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY},x-honeycomb-dataset=${HONEYCOMB_DATASET:-workshop}"
-  export OTEL_SERVICE_NAME="node-year"
-
   if [[ -n "$2" ]] && [[ "$2" == "-b" ]]; then
     node -r ./tracing.js node-year.js &
   else
@@ -63,11 +58,6 @@ python_year() {
   cd python-year || exit
 
   pip install -r requirements.txt
-
-  export OTEL_METRICS_EXPORTER="none"
-  export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io"
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY},x-honeycomb-dataset=${HONEYCOMB_DATASET:-workshop}"
-  export OTEL_SERVICE_NAME="python-year"
 
   if [[ -n "$2" ]] && [[ "$2" == "-b" ]]; then
     opentelemetry-instrument uvicorn python-year:app --host 0.0.0.0 --port 6001 &
@@ -86,11 +76,6 @@ case $1 in
 "go-year")
   echo "go-year"
   go_year "$@"
-  ;;
-
-"java-name")
-  echo "java-name"
-  java_name "$@"
   ;;
 
 "java-year")

--- a/05-propagation/stop.sh
+++ b/05-propagation/stop.sh
@@ -2,7 +2,7 @@
 
 case "$1" in
 
-"go-year" | "go-name" | "java-year" | "java-name" | "node-year" | "node-name")
+"go-year" | "go-name" | "java-year" | "java-name" | "node-year" | "python-year")
   pkill -f "$1"
   ;;
 
@@ -13,7 +13,7 @@ case "$1" in
   pkill -f java-year
   pkill -f java-name
   pkill -f node-year
-  pkill -f node-name
+  pkill -f python-year
   ;;
 
 *)

--- a/06-multi-span-attributes/go-year/main.go
+++ b/06-multi-span-attributes/go-year/main.go
@@ -7,20 +7,15 @@ import (
 	"log"
 	"math/rand"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/gorilla/mux"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
-	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	"go.opentelemetry.io/otel/trace"
-	"google.golang.org/grpc/credentials"
 )
 
 var years = []int{2015, 2016, 2017, 2018, 2019, 2020}
@@ -109,38 +104,20 @@ func addRecursiveSpan(ctx context.Context, depth int, maxDepth int) {
 }
 
 func initTracer() func() {
-	apikey, _ := os.LookupEnv("HONEYCOMB_API_KEY")
-	dataset, _ := os.LookupEnv("HONEYCOMB_DATASET")
 
-	// Set GRPC options to establish an insecure connection to an OpenTelemetry Collector
-	opts := []otlptracegrpc.Option{
-		otlptracegrpc.WithTLSCredentials(credentials.NewClientTLSFromCert(nil, "")),
-		otlptracegrpc.WithEndpoint("api.honeycomb.io:443"),
-		otlptracegrpc.WithHeaders(map[string]string{
-			"x-honeycomb-team":    apikey,
-			"x-honeycomb-dataset": dataset,
-		}),
-	}
+	ctx := context.Background()
 
-	// Create the exporter
-	exporter, err := otlptrace.New(context.Background(), otlptracegrpc.NewClient(opts...))
+	exporter, err := otlptracegrpc.New(ctx)
 	if err != nil {
-		log.Fatalf("failed to create Otel exporter: %v", err)
+		log.Fatal(err)
 	}
-
 	provider := sdktrace.NewTracerProvider(
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 		sdktrace.WithBatcher(exporter),
-		sdktrace.WithResource(resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceNameKey.String("go-year"),
-		)),
 	)
 	otel.SetTracerProvider(provider)
 
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
 
-	// This callback will ensure all spans get flushed before the program exits.
 	return func() {
 		ctx := context.Background()
 		err := provider.Shutdown(ctx)

--- a/06-multi-span-attributes/run.sh
+++ b/06-multi-span-attributes/run.sh
@@ -13,6 +13,11 @@ go_name() {
 }
 
 go_year() {
+  export OTEL_METRICS_EXPORTER="none"
+  export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io:443"
+  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY},x-honeycomb-dataset=${HONEYCOMB_DATASET:-workshop}"
+  export OTEL_SERVICE_NAME="go-year"
+
   cd go-year || exit
 
   go build -o bin/go-year main.go

--- a/06-multi-span-attributes/stop.sh
+++ b/06-multi-span-attributes/stop.sh
@@ -2,7 +2,7 @@
 
 case "$1" in
 
-"go-year" | "go-name" | "java-year" | "java-name" | "node-year" | "node-name")
+"go-year" | "go-name" | "java-year" | "java-name" | "node-year" | "python-year")
   pkill -f "$1"
   ;;
 
@@ -13,7 +13,7 @@ case "$1" in
   pkill -f java-year
   pkill -f java-name
   pkill -f node-year
-  pkill -f node-name
+  pkill -f python-year
   ;;
 
 *)


### PR DESCRIPTION
- Updates go initTracer to use `OTEL_*` environment variables (fewer lines of code)
- Updates run.sh script to make `OTEL_*` env vars global
- Fixes stop.sh script for python and node