### PR TITLE
optimization on run.sh and improved setup for better setting api key …

### DIFF
--- a/00-start/run.sh
+++ b/00-start/run.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
+# get the path of the script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+module_step=$(basename "$PWD")
+
 run_go() {
-  cd "$1" || exit
+  cd "$SCRIPT_DIR/$1" || exit
 
   go build -o "bin/$1" main
 
@@ -14,8 +19,7 @@ run_go() {
 
 run_java() {
 
-  cd "$1" || exit
-
+  cd "$SCRIPT_DIR/$1" || exit
   gradle bootJar
 
   # Run your app with the auto-instrumentation agent as a sidecar
@@ -27,7 +31,7 @@ run_java() {
 }
 
 run_node() {
-  cd "$1" || exit
+  cd "$SCRIPT_DIR/$1" || exit
 
   npm install
 
@@ -39,36 +43,40 @@ run_node() {
 }
 
 run_python() {
-  cd "$1" || exit
+  cd "$SCRIPT_DIR/$1" || exit
 
   pip install -r requirements.txt
-  opentelemetry-bootstrap -a install
+
+  port=6001
+  if [[ "$1" == "python-name" ]]; then
+    port=6002
+  fi
 
   if [[ -n "$2" ]] && [[ "$2" == "-b" ]]; then
-    uvicorn "$1:app" --host 0.0.0.0 --port 6001 &
+    uvicorn "$1:app" --host 0.0.0.0 --port $port &
   else
-    uvicorn "$1:app" --host 0.0.0.0 --port 6001
+    uvicorn "$1:app" --host 0.0.0.0 --port $port
   fi
 }
 
 case $1 in
 
-"go-year")
+"go-year" | "go-name")
   echo "$1"
   run_go "$@"
   ;;
 
-"java-year")
+"java-year" | "java-name")
   echo "$1"
   run_java "$@"
   ;;
 
-"node-year")
+"node-year" | "node-name")
   echo "$1"
   run_node "$@"
   ;;
 
-"python-year")
+"python-year" | "python-name")
   echo "$1"
   run_python "$@"
   ;;

--- a/01-instrumented/run.sh
+++ b/01-instrumented/run.sh
@@ -4,21 +4,14 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 module_step=$(basename "$PWD")
-OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io:443"
 OTEL_RESOURCE_ATTRIBUTES="workshop-step=${module_step}"
 OTEL_SERVICE_NAME="$1"
-OTEL_METRICS_EXPORTER="none"
-OTEL_LOGS_EXPORTER="none"
 
 run_go() {
   cd "$SCRIPT_DIR/$1" || exit
-  export $(cat "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
-  export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
-  export OTEL_EXPORTER_OTLP_HEADERS=$OTEL_EXPORTER_OTLP_HEADERS
+  export $(envsubst < "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs) > /dev/null
   export OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES
   export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
-  export OTEL_METRICS_EXPORTER=$OTEL_METRICS_EXPORTER
 
   go build -o "bin/$1" main
 
@@ -32,13 +25,9 @@ run_go() {
 run_java() {
 
   cd "$SCRIPT_DIR/$1" || exit
-  export $(cat "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
-  export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
-  export OTEL_EXPORTER_OTLP_HEADERS=$OTEL_EXPORTER_OTLP_HEADERS
+  export $(envsubst < "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
   export OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES
   export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
-  export OTEL_METRICS_EXPORTER=$OTEL_METRICS_EXPORTER
   gradle bootJar
 
   # Run your app with the auto-instrumentation agent as a sidecar
@@ -51,13 +40,9 @@ run_java() {
 
 run_node() {
   cd "$SCRIPT_DIR/$1" || exit
-  export $(cat "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
-  export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
-  export OTEL_EXPORTER_OTLP_HEADERS=$OTEL_EXPORTER_OTLP_HEADERS
+  export $(envsubst < "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
   export OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES
   export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
-  export OTEL_METRICS_EXPORTER=$OTEL_METRICS_EXPORTER
 
   npm install
 
@@ -70,13 +55,9 @@ run_node() {
 
 run_python() {
   cd "$SCRIPT_DIR/$1" || exit
-  export $(cat "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
-  export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
-  export OTEL_EXPORTER_OTLP_HEADERS=$OTEL_EXPORTER_OTLP_HEADERS
+  export $(envsubst < "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
   export OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES
   export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
-  export OTEL_METRICS_EXPORTER=$OTEL_METRICS_EXPORTER  # export OTEL_LOGS_EXPORTER=console
 
   pip install -r requirements.txt
   opentelemetry-bootstrap -a install

--- a/02-asynchronous/run.sh
+++ b/02-asynchronous/run.sh
@@ -4,21 +4,14 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 module_step=$(basename "$PWD")
-OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io:443"
 OTEL_RESOURCE_ATTRIBUTES="workshop-step=${module_step}"
 OTEL_SERVICE_NAME="$1"
-OTEL_METRICS_EXPORTER="none"
-OTEL_LOGS_EXPORTER="none"
 
 run_go() {
   cd "$SCRIPT_DIR/$1" || exit
-  export $(cat "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
-  export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
-  export OTEL_EXPORTER_OTLP_HEADERS=$OTEL_EXPORTER_OTLP_HEADERS
+  export $(envsubst < "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs) > /dev/null
   export OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES
   export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
-  export OTEL_METRICS_EXPORTER=$OTEL_METRICS_EXPORTER
 
   go build -o "bin/$1" main
 
@@ -32,13 +25,9 @@ run_go() {
 run_java() {
 
   cd "$SCRIPT_DIR/$1" || exit
-  export $(cat "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
-  export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
-  export OTEL_EXPORTER_OTLP_HEADERS=$OTEL_EXPORTER_OTLP_HEADERS
+  export $(envsubst < "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
   export OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES
   export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
-  export OTEL_METRICS_EXPORTER=$OTEL_METRICS_EXPORTER
   gradle bootJar
 
   # Run your app with the auto-instrumentation agent as a sidecar
@@ -51,13 +40,9 @@ run_java() {
 
 run_node() {
   cd "$SCRIPT_DIR/$1" || exit
-  export $(cat "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
-  export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
-  export OTEL_EXPORTER_OTLP_HEADERS=$OTEL_EXPORTER_OTLP_HEADERS
+  export $(envsubst < "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
   export OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES
   export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
-  export OTEL_METRICS_EXPORTER=$OTEL_METRICS_EXPORTER
 
   npm install
 
@@ -70,13 +55,9 @@ run_node() {
 
 run_python() {
   cd "$SCRIPT_DIR/$1" || exit
-  export $(cat "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
-  export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
-  export OTEL_EXPORTER_OTLP_HEADERS=$OTEL_EXPORTER_OTLP_HEADERS
+  export $(envsubst < "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
   export OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES
   export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
-  export OTEL_METRICS_EXPORTER=$OTEL_METRICS_EXPORTER  # export OTEL_LOGS_EXPORTER=console
 
   pip install -r requirements.txt
   opentelemetry-bootstrap -a install

--- a/03-context/run.sh
+++ b/03-context/run.sh
@@ -4,21 +4,14 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 module_step=$(basename "$PWD")
-OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io:443"
 OTEL_RESOURCE_ATTRIBUTES="workshop-step=${module_step}"
 OTEL_SERVICE_NAME="$1"
-OTEL_METRICS_EXPORTER="none"
-OTEL_LOGS_EXPORTER="none"
 
 run_go() {
   cd "$SCRIPT_DIR/$1" || exit
-  export $(cat "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
-  export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
-  export OTEL_EXPORTER_OTLP_HEADERS=$OTEL_EXPORTER_OTLP_HEADERS
+  export $(envsubst < "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs) > /dev/null
   export OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES
   export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
-  export OTEL_METRICS_EXPORTER=$OTEL_METRICS_EXPORTER
 
   go build -o "bin/$1" main
 
@@ -32,13 +25,9 @@ run_go() {
 run_java() {
 
   cd "$SCRIPT_DIR/$1" || exit
-  export $(cat "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
-  export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
-  export OTEL_EXPORTER_OTLP_HEADERS=$OTEL_EXPORTER_OTLP_HEADERS
+  export $(envsubst < "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
   export OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES
   export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
-  export OTEL_METRICS_EXPORTER=$OTEL_METRICS_EXPORTER
   gradle bootJar
 
   # Run your app with the auto-instrumentation agent as a sidecar
@@ -51,13 +40,9 @@ run_java() {
 
 run_node() {
   cd "$SCRIPT_DIR/$1" || exit
-  export $(cat "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
-  export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
-  export OTEL_EXPORTER_OTLP_HEADERS=$OTEL_EXPORTER_OTLP_HEADERS
+  export $(envsubst < "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
   export OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES
   export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
-  export OTEL_METRICS_EXPORTER=$OTEL_METRICS_EXPORTER
 
   npm install
 
@@ -70,13 +55,9 @@ run_node() {
 
 run_python() {
   cd "$SCRIPT_DIR/$1" || exit
-  export $(cat "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
-  export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
-  export OTEL_EXPORTER_OTLP_HEADERS=$OTEL_EXPORTER_OTLP_HEADERS
+  export $(envsubst < "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
   export OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES
   export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
-  export OTEL_METRICS_EXPORTER=$OTEL_METRICS_EXPORTER  # export OTEL_LOGS_EXPORTER=console
 
   pip install -r requirements.txt
   opentelemetry-bootstrap -a install

--- a/04-span-events/run.sh
+++ b/04-span-events/run.sh
@@ -4,21 +4,14 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 module_step=$(basename "$PWD")
-OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io:443"
 OTEL_RESOURCE_ATTRIBUTES="workshop-step=${module_step}"
 OTEL_SERVICE_NAME="$1"
-OTEL_METRICS_EXPORTER="none"
-OTEL_LOGS_EXPORTER="none"
 
 run_go() {
   cd "$SCRIPT_DIR/$1" || exit
-  export $(cat "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
-  export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
-  export OTEL_EXPORTER_OTLP_HEADERS=$OTEL_EXPORTER_OTLP_HEADERS
+  export $(envsubst < "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs) > /dev/null
   export OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES
   export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
-  export OTEL_METRICS_EXPORTER=$OTEL_METRICS_EXPORTER
 
   go build -o "bin/$1" main
 
@@ -32,13 +25,9 @@ run_go() {
 run_java() {
 
   cd "$SCRIPT_DIR/$1" || exit
-  export $(cat "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
-  export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
-  export OTEL_EXPORTER_OTLP_HEADERS=$OTEL_EXPORTER_OTLP_HEADERS
+  export $(envsubst < "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
   export OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES
   export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
-  export OTEL_METRICS_EXPORTER=$OTEL_METRICS_EXPORTER
   gradle bootJar
 
   # Run your app with the auto-instrumentation agent as a sidecar
@@ -51,13 +40,9 @@ run_java() {
 
 run_node() {
   cd "$SCRIPT_DIR/$1" || exit
-  export $(cat "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
-  export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
-  export OTEL_EXPORTER_OTLP_HEADERS=$OTEL_EXPORTER_OTLP_HEADERS
+  export $(envsubst < "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
   export OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES
   export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
-  export OTEL_METRICS_EXPORTER=$OTEL_METRICS_EXPORTER
 
   npm install
 
@@ -70,13 +55,9 @@ run_node() {
 
 run_python() {
   cd "$SCRIPT_DIR/$1" || exit
-  export $(cat "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
-  export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
-  export OTEL_EXPORTER_OTLP_HEADERS=$OTEL_EXPORTER_OTLP_HEADERS
+  export $(envsubst < "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
   export OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES
   export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
-  export OTEL_METRICS_EXPORTER=$OTEL_METRICS_EXPORTER  # export OTEL_LOGS_EXPORTER=console
 
   pip install -r requirements.txt
   opentelemetry-bootstrap -a install

--- a/05-span-links/run.sh
+++ b/05-span-links/run.sh
@@ -4,21 +4,14 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 module_step=$(basename "$PWD")
-OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io:443"
 OTEL_RESOURCE_ATTRIBUTES="workshop-step=${module_step}"
 OTEL_SERVICE_NAME="$1"
-OTEL_METRICS_EXPORTER="none"
-OTEL_LOGS_EXPORTER="none"
 
 run_go() {
   cd "$SCRIPT_DIR/$1" || exit
-  export $(cat "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
-  export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
-  export OTEL_EXPORTER_OTLP_HEADERS=$OTEL_EXPORTER_OTLP_HEADERS
+  export $(envsubst < "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs) > /dev/null
   export OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES
   export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
-  export OTEL_METRICS_EXPORTER=$OTEL_METRICS_EXPORTER
 
   go build -o "bin/$1" main
 
@@ -32,13 +25,9 @@ run_go() {
 run_java() {
 
   cd "$SCRIPT_DIR/$1" || exit
-  export $(cat "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
-  export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
-  export OTEL_EXPORTER_OTLP_HEADERS=$OTEL_EXPORTER_OTLP_HEADERS
+  export $(envsubst < "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
   export OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES
   export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
-  export OTEL_METRICS_EXPORTER=$OTEL_METRICS_EXPORTER
   gradle bootJar
 
   # Run your app with the auto-instrumentation agent as a sidecar
@@ -51,13 +40,9 @@ run_java() {
 
 run_node() {
   cd "$SCRIPT_DIR/$1" || exit
-  export $(cat "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
-  export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
-  export OTEL_EXPORTER_OTLP_HEADERS=$OTEL_EXPORTER_OTLP_HEADERS
+  export $(envsubst < "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
   export OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES
   export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
-  export OTEL_METRICS_EXPORTER=$OTEL_METRICS_EXPORTER
 
   npm install
 
@@ -70,13 +55,9 @@ run_node() {
 
 run_python() {
   cd "$SCRIPT_DIR/$1" || exit
-  export $(cat "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
-  export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
-  export OTEL_EXPORTER_OTLP_HEADERS=$OTEL_EXPORTER_OTLP_HEADERS
+  export $(envsubst < "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
   export OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES
   export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
-  export OTEL_METRICS_EXPORTER=$OTEL_METRICS_EXPORTER  # export OTEL_LOGS_EXPORTER=console
 
   pip install -r requirements.txt
   opentelemetry-bootstrap -a install

--- a/06-propagation/run.sh
+++ b/06-propagation/run.sh
@@ -4,21 +4,14 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 module_step=$(basename "$PWD")
-OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io:443"
 OTEL_RESOURCE_ATTRIBUTES="workshop-step=${module_step}"
 OTEL_SERVICE_NAME="$1"
-OTEL_METRICS_EXPORTER="none"
-OTEL_LOGS_EXPORTER="none"
 
 run_go() {
   cd "$SCRIPT_DIR/$1" || exit
-  export $(cat "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
-  export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
-  export OTEL_EXPORTER_OTLP_HEADERS=$OTEL_EXPORTER_OTLP_HEADERS
+  export $(envsubst < "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs) > /dev/null
   export OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES
   export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
-  export OTEL_METRICS_EXPORTER=$OTEL_METRICS_EXPORTER
 
   go build -o "bin/$1" main
 
@@ -32,13 +25,9 @@ run_go() {
 run_java() {
 
   cd "$SCRIPT_DIR/$1" || exit
-  export $(cat "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
-  export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
-  export OTEL_EXPORTER_OTLP_HEADERS=$OTEL_EXPORTER_OTLP_HEADERS
+  export $(envsubst < "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
   export OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES
   export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
-  export OTEL_METRICS_EXPORTER=$OTEL_METRICS_EXPORTER
   gradle bootJar
 
   # Run your app with the auto-instrumentation agent as a sidecar
@@ -51,13 +40,9 @@ run_java() {
 
 run_node() {
   cd "$SCRIPT_DIR/$1" || exit
-  export $(cat "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
-  export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
-  export OTEL_EXPORTER_OTLP_HEADERS=$OTEL_EXPORTER_OTLP_HEADERS
+  export $(envsubst < "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
   export OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES
   export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
-  export OTEL_METRICS_EXPORTER=$OTEL_METRICS_EXPORTER
 
   npm install
 
@@ -70,13 +55,9 @@ run_node() {
 
 run_python() {
   cd "$SCRIPT_DIR/$1" || exit
-  export $(cat "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
-  export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
-  export OTEL_EXPORTER_OTLP_HEADERS=$OTEL_EXPORTER_OTLP_HEADERS
+  export $(envsubst < "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
   export OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES
   export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
-  export OTEL_METRICS_EXPORTER=$OTEL_METRICS_EXPORTER  # export OTEL_LOGS_EXPORTER=console
 
   pip install -r requirements.txt
   opentelemetry-bootstrap -a install

--- a/07-logging/run.sh
+++ b/07-logging/run.sh
@@ -4,22 +4,14 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 module_step=$(basename "$PWD")
-OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io:443"
 OTEL_RESOURCE_ATTRIBUTES="workshop-step=${module_step}"
 OTEL_SERVICE_NAME="$1"
-OTEL_METRICS_EXPORTER="none"
-OTEL_LOGS_EXPORTER="otlp"
 
 run_go() {
   cd "$SCRIPT_DIR/$1" || exit
-  export $(cat "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
-  export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
-  export OTEL_EXPORTER_OTLP_HEADERS=$OTEL_EXPORTER_OTLP_HEADERS
+  export $(envsubst < "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs) > /dev/null
   export OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES
   export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
-  export OTEL_METRICS_EXPORTER=$OTEL_METRICS_EXPORTER
-  export OTEL_LOGS_EXPORTER=$OTEL_LOGS_EXPORTER
 
   go build -o "bin/$1" main
 
@@ -33,14 +25,9 @@ run_go() {
 run_java() {
 
   cd "$SCRIPT_DIR/$1" || exit
-  export $(cat "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
-  export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
-  export OTEL_EXPORTER_OTLP_HEADERS=$OTEL_EXPORTER_OTLP_HEADERS
+  export $(envsubst < "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
   export OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES
   export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
-  export OTEL_METRICS_EXPORTER=$OTEL_METRICS_EXPORTER
-  export OTEL_LOGS_EXPORTER=$OTEL_LOGS_EXPORTER
   gradle bootJar
 
   # Run your app with the auto-instrumentation agent as a sidecar
@@ -53,14 +40,9 @@ run_java() {
 
 run_node() {
   cd "$SCRIPT_DIR/$1" || exit
-  export $(cat "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
-  export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
-  export OTEL_EXPORTER_OTLP_HEADERS=$OTEL_EXPORTER_OTLP_HEADERS
+  export $(envsubst < "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
   export OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES
   export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
-  export OTEL_METRICS_EXPORTER=$OTEL_METRICS_EXPORTER
-  export OTEL_LOGS_EXPORTER=$OTEL_LOGS_EXPORTER
 
   npm install
 
@@ -73,16 +55,11 @@ run_node() {
 
 run_python() {
   cd "$SCRIPT_DIR/$1" || exit
-  export $(cat "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
-  export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
-  export OTEL_EXPORTER_OTLP_HEADERS=$OTEL_EXPORTER_OTLP_HEADERS
+  export $(envsubst < "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
   export OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES
   export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
-  export OTEL_METRICS_EXPORTER=$OTEL_METRICS_EXPORTER
   export OTEL_PYTHON_LOG_CORRELATION=true
   export OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
-  export OTEL_LOGS_EXPORTER=$OTEL_LOGS_EXPORTER
   # export OTEL_LOGS_EXPORTER=console
 
   pip install -r requirements.txt

--- a/08-frontend/package.json
+++ b/08-frontend/package.json
@@ -6,7 +6,7 @@
     "set-env": "export $(cat .env.development | grep \"^[^#;]\" | xargs) > /dev/null",
     "dev": "npm run set-env && next dev --turbopack --port 6003",
     "build": "next build",
-    "start": "concurrently \"npm run set-env && next dev --turbopack --port 6003\" \"../07-logging/run.sh go-year\" \"../07-logging/run.sh java-name\"",
+    "start": "concurrently \"npm run set-env && next dev --turbopack --port 6003\" \"../07-logging/run.sh go-year\" \"../07-logging/run.sh node-name\"",
     "lint": "next lint"
   },
   "dependencies": {

--- a/08-frontend/run.sh
+++ b/08-frontend/run.sh
@@ -4,21 +4,21 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 module_step=$(basename "$PWD")
-OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io:443"
 OTEL_RESOURCE_ATTRIBUTES="workshop-step=${module_step}"
 OTEL_SERVICE_NAME="$1"
-OTEL_METRICS_EXPORTER="none"
-OTEL_LOGS_EXPORTER="otlp"
 OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
 
 run_frontend() {
-  export $(cat "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
-  export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
-  export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
+  export $(envsubst < "$SCRIPT_DIR/../.env" | grep "^[^#;]" | xargs)
   export OTEL_RESOURCE_ATTRIBUTES=$OTEL_RESOURCE_ATTRIBUTES
   export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
-  export OTEL_METRICS_EXPORTER=$OTEL_METRICS_EXPORTER
   export OTEL_EXPORTER_OTLP_PROTOCOL=$OTEL_EXPORTER_OTLP_PROTOCOL
+
+  # Replace the apiKey in the observability.tsx file
+  TSX_FILE="$SCRIPT_DIR/components/observability.tsx"
+  if [[ -f "$TSX_FILE" ]]; then
+    sed -i '' "s/apiKey: '[^']*',/apiKey: '$HONEYCOMB_API_KEY',/" "$TSX_FILE"
+  fi
 
   npm install
 

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -11,4 +11,8 @@ fi
 
 echo "setting up environment..."
 echo "HONEYCOMB_API_KEY=$1" > .env
+echo "OTEL_EXPORTER_OTLP_HEADERS=\"x-honeycomb-team=$1\"" >> .env
+echo "OTEL_EXPORTER_OTLP_ENDPOINT=https://api.honeycomb.io:443" >> .env
+echo "OTEL_METRICS_EXPORTER=\"none\"" >> .env
+echo "OTEL_LOGS_EXPORTER=\"otlp\"" >> .env
 echo "done"


### PR DESCRIPTION
## Short description of the changes

- run.sh script used to have tons of env export commands, but now optimized
- setup-env.sh now added all the common env variables
- as for 08-frontend, /components/observability.tsx needs to be updated with the proper honeycomb api key. This fix sets the api key on every run of the frontend (./run.sh) so that proper value is populated.
- also changed the backend application for 08-frontend to be of node, and golang instead of python and java, since starting up python and java take more time and slower.